### PR TITLE
Implemented a transition effect for the mobile sidebar navigation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -17,12 +17,12 @@ header {
 }
 
 .header-sec {
-  max-width: 1440px; /* or any max width you prefer */
+  max-width: 1440px;
   margin: 0 auto;
   padding: 0 16px;
   display: flex;
   justify-content: space-between;
-  align-items: center; /* Vertically align items in the middle */
+  align-items: center;
 }
 
 .navigation {
@@ -65,10 +65,17 @@ header {
   background-color: #e129265e;
   backdrop-filter: blur(10px);
   box-shadow: -10px 0 10px rgba(0, 0, 0, 0.1);
-  display: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
   flex-direction: column;
   align-items: flex-start;
   padding-top: 20px;
+}
+
+.sidebar.show {
+  opacity: 1;
+  visibility: visible;
 }
 
 .sidebar li {
@@ -82,6 +89,10 @@ header {
 
 .hidemobile {
   display: none;
+}
+
+.hideondesktop {
+  display: flex; /* Show on mobile */
 }
 
 .main-text h1 {

--- a/js/main.js
+++ b/js/main.js
@@ -1,15 +1,13 @@
 const sidebar = document.querySelector(".sidebar");
-const showSidebarButton = document.querySelector(".hideondesktop");
+const showSidebarButton = document.querySelector(".hideondesktop a");
 const hideSidebarButton = document.querySelector(".sidebar li:first-child a");
 
 function showSidebar() {
-  const sidebar = document.querySelector(".sidebar");
-  sidebar.style.display = "flex";
+  sidebar.classList.add("show");
 }
 
 function hideSidebar() {
-  const sidebar = document.querySelector(".sidebar");
-  sidebar.style.display = "none";
+  sidebar.classList.remove("show");
 }
 
 showSidebarButton.addEventListener("click", showSidebar);


### PR DESCRIPTION
This commit introduces a smooth transition for the mobile sidebar navigation. When the sidebar is activated by clicking the hamburger menu icon, it fades in, and when the close icon is clicked, it fades out, providing a more interactive and visually appealing navigation experience.